### PR TITLE
Corrected float+string concatenate

### DIFF
--- a/xapp_orchestrater/dev/xapp_onboarder/xapp_onboarder/repo_manager/repo_manager.py
+++ b/xapp_orchestrater/dev/xapp_onboarder/xapp_onboarder/repo_manager/repo_manager.py
@@ -141,7 +141,7 @@ class repoManager():
 
     def download_xapp_chart(self, xapp_chart_name, version):
 
-        request_path = self.repo_url+'/charts/'+xapp_chart_name+'-'+version+'.tgz'
+        request_path = self.repo_url+'/charts/'+xapp_chart_name+'-'+str(version)+'.tgz'
         try:
             response = self.retry_session.get(request_path, timeout=settings.HTTP_TIME_OUT)
         except Exception as err:


### PR DESCRIPTION
Depending on python's version, the "version" variable might be treated as a float, which must be explicitly converted to string. I had problems with this working on Python 3.8.